### PR TITLE
Update readme example to be correct

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ npm install --save postcss-unprefix
 
 ```javascript
 var postcss = require("gulp-postcss");
-var unprefix = require("unprefix");
+var unprefix = require("postcss-unprefix");
 var autoprefixer = require("autoprefixer");
 
 gulp.task("clear-css", function () {


### PR DESCRIPTION
Module name is `postcss-unprefix`, but example code includes `require('unprefix')`.

I've verified personally that the former is correct.